### PR TITLE
fix(terraform): remove unused provider profile configuration

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -13,8 +13,7 @@ terraform {
 }
 
 provider "aws" {
-  profile = "projet-forum"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 data "aws_ami" "amazon_linux_2" {


### PR DESCRIPTION
removed the aws profile configuration from provider block as it is not used.